### PR TITLE
[EN-1388] Move ansible playbooks roles into standalone repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,40 @@
-# ansible-role-zerorpc-python
+Ansible Role: zerorpc Python
+=========
+
+Install zerorpc Python on CentOS server.
+
+Requirements
+------------
+
+Written in Ansible 1.9.*
+
+Role Variables
+--------------
+
+Available variables are listed below, along with default values (see `defaults/main.yml`):
+
+### zerorpc_version
+
+Install zerorpc package, default version is `0.5.1`.
+
+Dependencies
+------------
+
+juwai.python27
+
+Example Playbook
+----------------
+
+    - hosts: servers
+      roles:
+        - juwai.zerorpc-python
+
+License
+-------
+
+MIT / BSD
+
+Author Information
+------------------
+
+This role was created in 2016 by [Juwai Limited](http://www.juwai.com).

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# defaults file for zerorpc-python
+zerorpc_version: "0.5.1"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for zerorpc-python

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,16 @@
+---
+galaxy_info:
+  author: Juwai Limited
+  description:
+  company: Juwai Limited
+  license: MIT / BSD
+  min_ansible_version: 1.9
+  platforms:
+  - name: EL
+    versions:
+    - 6
+  - name: Amazon
+    versions:
+    - 2015.09
+dependencies:
+- role: python27

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,4 +14,4 @@ galaxy_info:
   #   - 2015.09
   galaxy_tags: [amazon, centos6, python, zerorpc]
 dependencies:
-- role: python27
+- role: juwai.python27

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 galaxy_info:
   author: Juwai Limited
-  description:
+  description: Install zerorpc Python on CentOS server
   company: Juwai Limited
   license: MIT / BSD
   min_ansible_version: 1.9
@@ -9,8 +9,9 @@ galaxy_info:
   - name: EL
     versions:
     - 6
-  - name: Amazon
-    versions:
-    - 2015.09
+  # - name: Amazon
+  #   versions:
+  #   - 2015.09
+  galaxy_tags: [amazon, centos6, python, zerorpc]
 dependencies:
 - role: python27

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+# tasks file for zerorpc-python
+- name: ensure zerorpc installed
+  pip:
+    name: zerorpc
+    state: present
+    version: "{{ zerorpc_version }}"
+    executable: "{{ executable_pip }}"
+  environment:
+    PATH: /usr/local/bin:/usr/bin:{{ ansible_env.PATH }}
+
+- name: make zerorpc available on the path
+  alternatives:
+    name: zerorpc
+    link: /usr/bin/zerorpc
+    path: /usr/local/bin/zerorpc

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for zerorpc-python


### PR DESCRIPTION
http://jira.juwai.com/browse/EN-1388

This role is for installing the zerorpc command line tool.

To test:
Install juwai.python27 role. Then run a playbook with this role against a Vagrant box or other CentOS/Amazon Linux instance.

No changes were made to this role when moving it here.

@juwai/platform @agirivera please review
